### PR TITLE
Rider 2021.2 support

### DIFF
--- a/Abc.MoqComplete/Abc.MoqComplete/Resources/plugin.xml
+++ b/Abc.MoqComplete/Abc.MoqComplete/Resources/plugin.xml
@@ -1,4 +1,4 @@
-<idea-plugin>
+<idea-plugin require-restart="true">
   <depends>com.intellij.modules.rider</depends>
   <idea-version since-build="211.6693" />
   <id>Abc.MoqComplete.Rider</id>

--- a/Abc.MoqComplete/Deployment/build_rider_plugin.ps1
+++ b/Abc.MoqComplete/Deployment/build_rider_plugin.ps1
@@ -39,6 +39,14 @@ function Zip
 }
 
 Unzip "$artifactDirectory\$PluginId.Rider.$Version.nupkg" "$artifactDirectory\$PluginId.Rider"
+
+# Move META-INF into its own JAR file
+$metaInfSourceLocation = "$artifactDirectory\$PluginId.Rider\META-INF"
+$libDirectory = "$artifactDirectory\$PluginId.Rider\lib"
+New-Item -Type Directory $libDirectory
+Zip "$libDirectory\$PluginId-$Version.jar" $metaInfSourceLocation
+Remove-Item -Recurse $metaInfSourceLocation
+
 rm "$artifactDirectory\$PluginId.Rider\_rels" -Force -Recurse
 rm "$artifactDirectory\$PluginId.Rider\package" -Force -Recurse
 rm "$artifactDirectory\$PluginId.Rider\*.xml"


### PR DESCRIPTION
It turns out that this plugin was relying on some sort of compatibility plugin loading in Rider.

It is considered "normal" to always have a `*.jar` file with `META-INF`, and loading of `META-INF` without a `*.jar` file was removed in 2021.2.

While we're still investigating whether it's possible/a good idea to enable this back, here's a quick fix for that mode.

I sincerely apologize for this sudden change in plugin loading behavior and its impact on the Rider side of this plugin.

This change is compatible with 2021.2 and 2021.1 as well.

Closes #25.