### PR TITLE
Remove usage of obsolete api TokenBeforeCaret

### DIFF
--- a/Abc.MoqComplete/Abc.MoqComplete/ContextActions/FillWithMock/FillParamWithMockContextAction.cs
+++ b/Abc.MoqComplete/Abc.MoqComplete/ContextActions/FillWithMock/FillParamWithMockContextAction.cs
@@ -73,14 +73,12 @@ namespace Abc.MoqComplete.ContextActions.FillWithMock
             if (_constructor == null)
                 return false;
 
-            var previousToken = _dataProvider.GetSelectedTreeNode<ITreeNode>();
+            var previousToken = _dataProvider.GetSelectedTreeNode<ITreeNode>()?.GetPreviousMeaningfulToken(includeThisNode: true);
             var previousTokenType = previousToken?.NodeType as ITokenNodeType;
             if (previousTokenType == null)
                 return false;
-            if (previousTokenType.TokenRepresentation == " ")
-                previousTokenType = previousToken.GetPreviousMeaningfulToken()?.NodeType as ITokenNodeType;
-            var nextTokenType = previousToken.GetNextMeaningfulToken()?.NodeType as ITokenNodeType;
-            if (previousTokenType == null || nextTokenType == null)
+            var nextTokenType = previousToken.GetNextMeaningfulToken(includeThisNode: false)?.NodeType as ITokenNodeType;
+            if (nextTokenType == null)
                 return false;
 
             var isAvailable = false;

--- a/Abc.MoqComplete/Abc.MoqComplete/ContextActions/FillWithMock/FillParamWithMockContextAction.cs
+++ b/Abc.MoqComplete/Abc.MoqComplete/ContextActions/FillWithMock/FillParamWithMockContextAction.cs
@@ -73,16 +73,17 @@ namespace Abc.MoqComplete.ContextActions.FillWithMock
             if (_constructor == null)
                 return false;
 
-            var previousTokenType = _dataProvider.TokenBeforeCaret?.NodeType as ITokenNodeType;
-            var nextTokenType = _dataProvider.TokenAfterCaret?.NodeType as ITokenNodeType;
+            var previousToken = _dataProvider.GetSelectedTreeNode<ITreeNode>();
+            var previousTokenType = previousToken?.NodeType as ITokenNodeType;
+            var nextTokenType = previousToken?.GetNextToken()?.NodeType as ITokenNodeType;
             if (previousTokenType == null || nextTokenType == null)
                 return false;
 
             if (previousTokenType.TokenRepresentation == " ")
-                previousTokenType = _dataProvider.PsiFile.FindTokenAt(_dataProvider.TokenBeforeCaret.GetTreeStartOffset() - 1)?.NodeType as ITokenNodeType;
+                previousTokenType = _dataProvider.PsiFile.FindTokenAt(previousToken.GetTreeStartOffset() - 1)?.NodeType as ITokenNodeType;
 
             if (nextTokenType.TokenRepresentation == " ")
-                nextTokenType = _dataProvider.PsiFile.FindTokenAt(_dataProvider.TokenBeforeCaret.GetTreeEndOffset() + 1)?.NodeType as ITokenNodeType;
+                nextTokenType = _dataProvider.PsiFile.FindTokenAt(previousToken.GetTreeEndOffset() + 1)?.NodeType as ITokenNodeType;
 
             if (previousTokenType == null || nextTokenType == null)
                 return false;

--- a/Abc.MoqComplete/Abc.MoqComplete/ContextActions/FillWithMock/FillParamWithMockContextAction.cs
+++ b/Abc.MoqComplete/Abc.MoqComplete/ContextActions/FillWithMock/FillParamWithMockContextAction.cs
@@ -75,16 +75,11 @@ namespace Abc.MoqComplete.ContextActions.FillWithMock
 
             var previousToken = _dataProvider.GetSelectedTreeNode<ITreeNode>();
             var previousTokenType = previousToken?.NodeType as ITokenNodeType;
-            var nextTokenType = previousToken?.GetNextToken()?.NodeType as ITokenNodeType;
-            if (previousTokenType == null || nextTokenType == null)
+            if (previousTokenType == null)
                 return false;
-
             if (previousTokenType.TokenRepresentation == " ")
-                previousTokenType = _dataProvider.PsiFile.FindTokenAt(previousToken.GetTreeStartOffset() - 1)?.NodeType as ITokenNodeType;
-
-            if (nextTokenType.TokenRepresentation == " ")
-                nextTokenType = _dataProvider.PsiFile.FindTokenAt(previousToken.GetTreeEndOffset() + 1)?.NodeType as ITokenNodeType;
-
+                previousTokenType = previousToken.GetPreviousMeaningfulToken()?.NodeType as ITokenNodeType;
+            var nextTokenType = previousToken.GetNextMeaningfulToken()?.NodeType as ITokenNodeType;
             if (previousTokenType == null || nextTokenType == null)
                 return false;
 


### PR DESCRIPTION
Fixes warning for obsolete api: 
`Warning CS0618 : 'IContextActionDataProvider.TokenBeforeCaret' is obsolete: 'To be removed. Use modern APIs like ContainingNodes/GetSelectedTreeNode'`

Linked issue: https://github.com/Abc-Arbitrage/Abc.MoqComplete/issues/42